### PR TITLE
Removing Object.prototype.fillDefaults

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events');
 const fs = require('fs');
 
-const { getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, fillMethods } = require("./resources/helper");
+const { getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, fillMethods, fillDefaults} = require("./resources/helper");
 
 Array.prototype.indexOfKey = indexOfKey;
 
@@ -41,7 +41,7 @@ class iCloud extends EventEmitter {
 
     function sessionInit(session) {
       // Session Validation. This adds default properties to the session that doesn't exists
-      session = session.fillDefaults({
+      session = fillDefaults(session, {
         username: username,
         password: password,
         auth: {
@@ -96,7 +96,7 @@ class iCloud extends EventEmitter {
       });
 
       // Session object is validated. Now, the (self) instance will be extended with session's properties using the fill defaults function.
-      self = self.fillDefaults(session);
+      self = fillDefaults(self, session);
 
       Object.keys(self.apps).forEach(function(appPropName) {
         if ("instanceName" in self.apps[appPropName]) {
@@ -351,17 +351,3 @@ class iCloud extends EventEmitter {
 }
 
 module.exports = iCloud;
-
-// Small self made fillDefaults method to fill an object with default properties
-
-Object.prototype.fillDefaults = function(defaults) {
-  Object.keys(defaults).forEach(key => {
-    if (!(key in this)) {
-      this[key] = defaults[key];
-    }
-    else if (typeof defaults[key] == "object" && defaults[key] != null) {
-      this[key] = this[key].fillDefaults(defaults[key]);
-    }
-  });
-  return this;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "cloud-kit",
+	"name": "apple-icloud",
 	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -9,10 +9,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
 			"integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
-				"json-schema-traverse": "0.3.1",
-				"json-stable-stringify": "1.0.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"json-schema-traverse": "^0.3.0",
+				"json-stable-stringify": "^1.0.1"
 			}
 		},
 		"asn1": {
@@ -56,7 +56,7 @@
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"boom": {
@@ -64,7 +64,7 @@
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"brace-expansion": {
@@ -72,7 +72,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -96,7 +96,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"concat-map": {
@@ -119,7 +119,7 @@
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"requires": {
-				"boom": "5.2.0"
+				"boom": "5.x.x"
 			},
 			"dependencies": {
 				"boom": {
@@ -127,7 +127,7 @@
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.x.x"
 					}
 				}
 			}
@@ -142,7 +142,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"deep-equal": {
@@ -161,7 +161,7 @@
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"extend": {
@@ -194,9 +194,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
 			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.5",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fs.realpath": {
@@ -209,7 +209,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -217,12 +217,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"har-schema": {
@@ -235,8 +235,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.2.3",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"hawk": {
@@ -244,10 +244,10 @@
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
-				"sntp": "2.0.2"
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
 			}
 		},
 		"hoek": {
@@ -260,9 +260,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"i": {
@@ -275,8 +275,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -315,7 +315,7 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -349,7 +349,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
 			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "~1.30.0"
 			}
 		},
 		"minimatch": {
@@ -357,7 +357,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -393,7 +393,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"path-is-absolute": {
@@ -416,12 +416,12 @@
 			"resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
 			"integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
 			"requires": {
-				"colors": "1.2.1",
-				"pkginfo": "0.4.1",
-				"read": "1.0.7",
-				"revalidator": "0.1.8",
-				"utile": "0.3.0",
-				"winston": "2.1.1"
+				"colors": "^1.1.2",
+				"pkginfo": "0.x.x",
+				"read": "1.0.x",
+				"revalidator": "0.1.x",
+				"utile": "0.3.x",
+				"winston": "2.1.x"
 			}
 		},
 		"punycode": {
@@ -439,7 +439,7 @@
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 			"requires": {
-				"mute-stream": "0.0.7"
+				"mute-stream": "~0.0.4"
 			}
 		},
 		"request": {
@@ -447,28 +447,28 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.1.0"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			}
 		},
 		"revalidator": {
@@ -481,7 +481,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -494,7 +494,7 @@
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
 			"integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"sshpk": {
@@ -502,14 +502,14 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-trace": {
@@ -527,7 +527,7 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
 			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			}
 		},
 		"tunnel-agent": {
@@ -535,7 +535,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -549,12 +549,12 @@
 			"resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
 			"integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
 			"requires": {
-				"async": "0.9.2",
-				"deep-equal": "0.2.2",
-				"i": "0.3.6",
-				"mkdirp": "0.5.1",
-				"ncp": "1.0.1",
-				"rimraf": "2.6.2"
+				"async": "~0.9.0",
+				"deep-equal": "~0.2.1",
+				"i": "0.3.x",
+				"mkdirp": "0.x.x",
+				"ncp": "1.0.x",
+				"rimraf": "2.x.x"
 			}
 		},
 		"uuid": {
@@ -567,9 +567,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"winston": {
@@ -577,13 +577,13 @@
 			"resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
 			"integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
 			"requires": {
-				"async": "1.0.0",
-				"colors": "1.0.3",
-				"cycle": "1.0.3",
-				"eyes": "0.1.8",
-				"isstream": "0.1.2",
-				"pkginfo": "0.3.1",
-				"stack-trace": "0.0.10"
+				"async": "~1.0.0",
+				"colors": "1.0.x",
+				"cycle": "1.0.x",
+				"eyes": "0.1.x",
+				"isstream": "0.1.x",
+				"pkginfo": "0.3.x",
+				"stack-trace": "0.0.x"
 			},
 			"dependencies": {
 				"async": {

--- a/resources/apps/Calendar.js
+++ b/resources/apps/Calendar.js
@@ -1,5 +1,5 @@
 const request = require('request');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, timeArray, arrayTime} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, timeArray, arrayTime, fillDefaults} = require("./../helper");
 
 
 module.exports = {
@@ -20,10 +20,10 @@ module.exports = {
         "endDate": endDate,
         "usertz": self.clientSettings.timezone
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies)
-        }.fillDefaults(self.clientSettings.defaultHeaders)
+        }, self.clientSettings.defaultHeaders)
       }, function(err, response, body) {
         if (err) {
           reject(err);
@@ -50,10 +50,10 @@ module.exports = {
             "endDate": endDate,
             "usertz": self.clientSettings.timezone
           }), {
-            headers: {
+            headers: fillDefaults({
               'Host': host,
               'Cookie': cookiesToStr(self.auth.cookies)
-            }.fillDefaults(self.clientSettings.defaultHeaders)
+            }, self.clientSettings.defaultHeaders)
           }, function(err, response, body) {
             if (err) {
               reject(err);
@@ -127,10 +127,10 @@ module.exports = {
         "endDate": endDate,
         "usertz": self.clientSettings.timezone
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies)
-        }.fillDefaults(self.clientSettings.defaultHeaders)
+		  }, self.clientSettings.defaultHeaders)
       }, function(err, response, body) {
         if (err) {
           reject(err);
@@ -166,7 +166,7 @@ module.exports = {
       }
     });
     //console.log(event.alarms);
-    event.recurrence = event.recurrence.fillDefaults({
+    event.recurrence = fillDefaults(event.recurrence, {
       pGuid: eventGuid,
       guid: eventGuid + '*MME-RID',
       recurrenceMasterStartDate: null, // [ 20170726, 2017, 7, 26, 19, 0, 1140 ]
@@ -181,7 +181,7 @@ module.exports = {
       weekDays: null
     });
 
-    event = event.fillDefaults({
+    event = fillDefaults(event, {
       guid: eventGuid,
       pGuid: 'home',
       etag: null,
@@ -294,11 +294,11 @@ module.exports = {
         "endDate": endDate,
         "usertz": self.clientSettings.timezone
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) {
@@ -407,11 +407,11 @@ module.exports = {
         }
         return args;
       })()), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) {
@@ -430,16 +430,4 @@ module.exports = {
 
 function getCTag(etag) {
   return "FT=-@RU=" + etag.substring(etag.search(/[^-]{8}-[^-]{4}-[^-]{4}-[^-]{4}-[^-]{12}/)) + "@S=" + etag.substring(etag.search(/[0-9]{1,}/), etag.search("@"))
-}
-
-Object.prototype.fillDefaults = function(defaults) {
-  Object.keys(defaults).forEach(key => {
-    if (!(key in this)) {
-      this[key] = defaults[key];
-    }
-    else if (typeof defaults[key] == "object" && defaults[key] != null) {
-      this[key] = this[key].fillDefaults(defaults[key]);
-    }
-  });
-  return this;
 }

--- a/resources/apps/Contacts.js
+++ b/resources/apps/Contacts.js
@@ -1,5 +1,5 @@
 const request = require('request');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, fillDefaults} = require("./../helper");
 
 
 module.exports = {
@@ -8,10 +8,10 @@ module.exports = {
     var host = getHostFromWebservice(self.account.webservices.contacts);
     var requestPromise = new Promise(function(resolve, reject) {
       request.get("https://" + host + "/co/startup?clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientId=" + self.clientId + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientVersion=2.1&dsid=" + self.account.dsInfo.dsid + "&locale=de_DE&order=first%2Clast", {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies)
-        }.fillDefaults(self.clientSettings.defaultHeaders)
+        }, self.clientSettings.defaultHeaders)
       }, function(err, response, body) {
         if (err) {
           reject(err);
@@ -47,11 +47,11 @@ module.exports = {
       }
       var host = getHostFromWebservice(self.account.webservices.contacts);
       request.post("https://" + host + "/co/contacts/card/?clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientId=" + self.clientId + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientVersion=2.1&dsid=" + self.account.dsInfo.dsid + "&method=" + method + "&prefToken=" + self.Contacts.prefToken + "&syncToken=" + self.Contacts.syncToken, {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+		  }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) {

--- a/resources/apps/Drive.js
+++ b/resources/apps/Drive.js
@@ -1,6 +1,6 @@
 const request = require('request');
 const https = require('https');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, fillDefaults} = require("./../helper");
 
 function isFolder(item) {
   var folderTypes = ["FOLDER", "APP_LIBRARY"];
@@ -149,11 +149,11 @@ module.exports = {
         ]);
         var host = getHostFromWebservice(self.account.webservices.drivews);
         request.post("https://" + host + "/retrieveItemDetailsInFolders?clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientId=" + self.clientId + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&dsid=" + self.account.dsInfo.dsid, {
-          headers: {
+          headers: fillDefaults({
             'Host': host,
             'Cookie': cookiesToStr(self.auth.cookies),
             'Content-Length': content.length
-          }.fillDefaults(self.clientSettings.defaultHeaders),
+          }, self.clientSettings.defaultHeaders),
           body: content
         }, function(err, response, body) {
           if (err) return callback(err);
@@ -171,10 +171,10 @@ module.exports = {
         var host = getHostFromWebservice(self.account.webservices.docws);
         var url = "https://" + host + "/ws/com.apple.CloudDocs/download/by_id?document_id=" + file.docwsid + "&token=" + self.auth.token + "&clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientId=" + self.clientId + "&dsid=" + self.account.dsInfo.dsid;
         request.get(url, {
-          headers: {
+          headers: fillDefaults({
             'Host': host,
             'Cookie': cookiesToStr(self.auth.cookies)
-          }.fillDefaults(self.clientSettings.defaultHeaders)
+          }, self.clientSettings.defaultHeaders)
         }, function(err, response, body) {
           if (err) return callback(err);
           file.contents = JSON.parse(body);
@@ -216,11 +216,11 @@ module.exports = {
           });
 
           request.post("https://" + host + "/createFolders?clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientId=" + self.clientId + "&dsid=" + self.account.dsInfo.dsid, {
-            headers: {
+            headers: fillDefaults({
               'Host': host,
               'Cookie': cookiesToStr(self.auth.cookies),
               'Content-Length': content.length
-            }.fillDefaults(self.clientSettings.defaultHeaders),
+            }, self.clientSettings.defaultHeaders),
             body: content
           }, function(err, response, body) {
             if (err) {
@@ -265,11 +265,11 @@ module.exports = {
             // Last item
             content = JSON.stringify(content);
             request.post("https://" + host + "/deleteItems?clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientId=" + self.clientId + "&dsid=" + self.account.dsInfo.dsid, {
-              headers: {
+              headers: fillDefaults({
                 'Host': host,
                 'Cookie': cookiesToStr(self.auth.cookies),
                 'Content-Length': content.length
-              }.fillDefaults(self.clientSettings.defaultHeaders),
+              }, self.clientSettings.defaultHeaders),
               body: content
             }, function(err, response, body) {
               if (err) {
@@ -313,11 +313,11 @@ module.exports = {
           if (index >= Object.keys(items).length - 1) {
             content = JSON.stringify(content);
             request.post("https://" + host + "/renameItems?clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientId=" + self.clientId + "&dsid=" + self.account.dsInfo.dsid, {
-              headers: {
+              headers: fillDefaults({
                 'Host': host,
                 'Cookie': cookiesToStr(self.auth.cookies),
                 'Content-Length': content.length
-              }.fillDefaults(self.clientSettings.defaultHeaders),
+              }, self.clientSettings.defaultHeaders),
               body: content
             }, function(err, response, body) {
               if (err) {
@@ -347,11 +347,11 @@ module.exports = {
     });
 
     request.post("https://" + host + "/ws/com.apple.CloudDocs/upload/web?token=NONE&clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientId=1356E574-A2A4-415F-A028-1BC2FB56FFB3&dsid=11298614181", {
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders),
+      }, self.clientSettings.defaultHeaders),
       body: content
     }, function(err, response, body) {
       if (err) return callback(err);
@@ -359,11 +359,11 @@ module.exports = {
       console.log(result);
       var content = '------WebKitFormBoundaryeKzg6g4kckug2g31\r\nContent-Disposition: form-data; name="files"; filename="file.txt"\r\nContent-Type: text/plain\r\n\r\n\r\n------WebKitFormBoundaryeKzg6g4kckug2g31--\r\n';
       var req = request.post(result[0].url, {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) return callback(err);

--- a/resources/apps/FindMe.js
+++ b/resources/apps/FindMe.js
@@ -1,5 +1,5 @@
 const request = require('request');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, fillDefaults} = require("./../helper");
 
 module.exports = {
   initialized: false,
@@ -53,11 +53,11 @@ module.exports = {
       "clientMasteringNumber": self.clientSettings.clientMasteringNumber,
       "dsid": self.account.dsInfo.dsid,
     }), {
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders),
+      }, self.clientSettings.defaultHeaders),
       body: content
     }, function(err, response, body) {
       if (err) return callback(err);
@@ -160,11 +160,11 @@ module.exports = {
       "clientMasteringNumber": self.clientSettings.clientMasteringNumber,
       "dsid": self.account.dsInfo.dsid,
     }), {
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders),
+      }, self.clientSettings.defaultHeaders),
       body: content
     }, function(err, response, body) {
       if (err) return callback(err);

--- a/resources/apps/Friends.js
+++ b/resources/apps/Friends.js
@@ -1,5 +1,5 @@
 const request = require('request');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, indexOfKey, paramStr} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, indexOfKey, paramStr, fillDefaults} = require("./../helper");
 
 
 
@@ -70,11 +70,11 @@ module.exports = {
         "clientMasteringNumber": self.clientSettings.clientMasteringNumber,
         "dsid": self.account.dsInfo.dsid,
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content,
         //gzip: true
       }, function(err, response, body) {

--- a/resources/apps/Mail.js
+++ b/resources/apps/Mail.js
@@ -1,5 +1,5 @@
 const request = require('request');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, timeArray, arrayTime} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, timeArray, arrayTime, fillDefaults} = require("./../helper");
 
 
 module.exports = {
@@ -193,7 +193,7 @@ module.exports = {
       }
       function sendMail(address, fullName) {
         var from = fullName + "<" + address + ">";
-        message = message.fillDefaults({
+        message = fillDefaults(message, {
           "date": new Date().toString(),
           "to": null,
           "subject": "",
@@ -233,7 +233,7 @@ module.exports = {
   createFolder(folder, callback = function() {}) {
     var self = this;
 
-    var params = folder.fillDefaults({
+    var params = fillDefaults(folder, {
       name: null,
       parent: null
     });
@@ -311,11 +311,11 @@ module.exports = {
       "clientMasteringNumber": self.clientSettings.clientMasteringNumber,
       "dsid": self.account.dsInfo.dsid
     }), {
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders),
+      }, self.clientSettings.defaultHeaders),
       body: content
     }, function(err, response, body) {
       if (err) return callback(err);
@@ -353,11 +353,11 @@ module.exports = {
         "clientMasteringNumber": self.clientSettings.clientMasteringNumber,
         "dsid": self.account.dsInfo.dsid
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) {
@@ -408,11 +408,11 @@ module.exports = {
       "clientMasteringNumber": self.clientSettings.clientMasteringNumber,
       "dsid": self.account.dsInfo.dsid
     }), {
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders),
+      }, self.clientSettings.defaultHeaders),
       body: content
     }, function(err, response, body) {
       if (err) return callback(err);

--- a/resources/apps/Notes.js
+++ b/resources/apps/Notes.js
@@ -1,5 +1,5 @@
 const request = require('request');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, timeArray, arrayTime} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, timeArray, arrayTime, fillDefaults} = require("./../helper");
 
 
 
@@ -114,11 +114,11 @@ module.exports = {
       "clientMasteringNumber": self.clientSettings.clientMasteringNumber,
       "dsid": self.account.dsInfo.dsid
     }), {
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders),
+      }, self.clientSettings.defaultHeaders),
       body: content
     }, function(err, response, body) {
       if (err) return callback(err);
@@ -205,11 +205,11 @@ module.exports = {
       "remapEnums": true,
       "ckjsVersion": "2.0"
     }), {
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders),
+      }, self.clientSettings.defaultHeaders),
       body: content
     }, function(err, response, body) {
       if (err) return callback(err);
@@ -230,11 +230,11 @@ module.exports = {
       "remapEnums": true,
       "ckjsVersion": "2.0"
     }), {
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders),
+      }, self.clientSettings.defaultHeaders),
       body: content
     }, function(err, response, body) {
       if (err) return console.error(err);

--- a/resources/apps/Photos.js
+++ b/resources/apps/Photos.js
@@ -1,5 +1,5 @@
 const request = require('request');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, paramString} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, paramString, fillDefaults} = require("./../helper");
 
 module.exports = {
   get(callback = function() {}) {
@@ -8,10 +8,10 @@ module.exports = {
 
     var photosPromise = new Promise(function(resolve, reject) {
       request.get("https://" + host + "/database/1/com.apple.photos.cloud/production/private/zones/list?remapEnums=true&ckjsBuildVersion=17DProjectDev77&ckjsVersion=2.0.5&getCurrentSyncToken=true&clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientId=" + self.clientId + "&dsid=" + self.account.dsInfo.dsid, {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies)
-        }.fillDefaults(self.clientSettings.defaultHeaders)
+        }, self.clientSettings.defaultHeaders)
       }, function(err, response, body) {
         if (err) {
           reject(err);
@@ -174,11 +174,11 @@ module.exports = {
 
         content = JSON.stringify(content);
         request.post("https://" + host + "/database/1/com.apple.photos.cloud/production/private/records/query?remapEnums=true&ckjsBuildVersion=17DProjectDev77&ckjsVersion=2.0.5&getCurrentSyncToken=true&clientBuildNumber=" + self.clientSettings.clientBuildNumber + "&clientMasteringNumber=" + self.clientSettings.clientMasteringNumber + "&clientId=" + self.clientId + "&dsid=" + self.account.dsInfo.dsid, {
-          headers: {
+          headers: fillDefaults({
             'Host': host,
             'Cookie': cookiesToStr(self.auth.cookies),
             'Content-Length': content.length
-          }.fillDefaults(self.clientSettings.defaultHeaders),
+          }, self.clientSettings.defaultHeaders),
           body: content
         }, function(err, response, body) {
           if (err) {
@@ -238,11 +238,11 @@ module.exports = {
     var content = fs.readFileSync(file);
     request("https://" + host + "/upload?filename=" + file.jpg + "&dsid=" + self.account.dsInfo.dsid + "&lastModDate=" + (new Date().getTime()) + "&timezoneOffset=-120", {
       method: "POST",
-      headers: {
+      headers: fillDefaults({
         'Host': host,
         'Cookie': cookiesToStr(self.auth.cookies),
         'Content-Length': content.length
-      }.fillDefaults(self.clientSettings.defaultHeaders)
+      }, self.clientSettings.defaultHeaders)
     }, function(err, response, body) {
       if (err) return callback(err);
       console.log(body);

--- a/resources/apps/Reminders.js
+++ b/resources/apps/Reminders.js
@@ -1,5 +1,5 @@
 const request = require('request');
-var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, timeArray, arrayTime} = require("./../helper");
+var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramString, paramStr, timeArray, arrayTime, fillDefaults} = require("./../helper");
 
 module.exports = {
   getOpenTasks(callback = function() {}) {
@@ -16,10 +16,10 @@ module.exports = {
         "lang": self.clientSettings.language,
         "usertz": self.clientSettings.timezone
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies)
-        }.fillDefaults(self.clientSettings.defaultHeaders)
+        }, self.clientSettings.defaultHeaders)
       }, function(err, response, body) {
         if (err) {
           reject(err);
@@ -96,11 +96,11 @@ module.exports = {
         "methodOverride": methodOverride || "POST",
         "ifMatch": task.etag ? encodeURIComponent(task.etag) : ""
       }), {
-        headers:  {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        } ,self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) {
@@ -143,11 +143,11 @@ module.exports = {
         "usertz": self.clientSettings.timezone,
         "methodOverride": "PUT"
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) {
@@ -175,10 +175,10 @@ module.exports = {
         "lang": self.clientSettings.language,
         "usertz": self.clientSettings.timezone
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies)
-        }.fillDefaults(self.clientSettings.defaultHeaders)
+        }, self.clientSettings.defaultHeaders)
       }, function(err, response, body) {
         if (err) {
           reject(err);
@@ -205,7 +205,7 @@ module.exports = {
   createTask(task, callback = function() {}) {
     var self = this;
 
-    task = task.fillDefaults({
+    task = fillDefaults(task, {
       "title": null,
       "description": null,
       "pGuid": "tasks",
@@ -282,11 +282,11 @@ module.exports = {
         }
         return args;
       })()), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) {
@@ -314,7 +314,7 @@ module.exports = {
   createCollection(collection, callback = function() {}) {
     var self = this;
 
-    collection = collection.fillDefaults({
+    collection = fillDefaults(collection, {
       "order": 2,
       "title": "New Collection",
       "color": "#b14bc9",

--- a/resources/helper.js
+++ b/resources/helper.js
@@ -1,5 +1,16 @@
 const Cookie = require('cookie');
 
+function fillDefaults(a, b) {
+	Object.keys(b).forEach(key => {
+		if (!(key in a)) {
+			a[key] = b[key];
+		} else if (typeof b[key] == "object" && b[key] != null) {
+			a[key] = fillDefaults(a[key], b[key]);
+		}
+	});
+	return a;
+}
+
 module.exports = {
   getHostFromWebservice(webservice) {
     return webservice.url.replace(":443", "").replace("https://", "");
@@ -75,8 +86,9 @@ module.exports = {
       }
     });
     return main;
-  }
-}
+  },
+  fillDefaults: fillDefaults
+};
 Function.prototype.applyConstructor = function(args) {
   return new (Function.prototype.bind.apply(this, [null].concat(args)));
 }

--- a/setup.js
+++ b/setup.js
@@ -4,7 +4,7 @@
   const request = require('request');
   const fs = require('fs');
 
-  var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramStr} = require("./resources/helper");
+  var {getHostFromWebservice, cookiesToStr, parseCookieStr, fillCookies, newId, indexOfKey, paramStr, fillDefaults} = require("./resources/helper");
 
   module.exports = {
 
@@ -128,11 +128,11 @@
         "clientMasteringNumber": self.clientSettings.clientMasteringNumber,
         "dsid": self.account.dsInfo.dsid
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content,
         //gzip: true
       }, function(err, response, body) {
@@ -156,11 +156,11 @@
           "dsid": self.account.dsInfo.dsid,
           "pcsEnabled": true
       }), {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies),
           'Content-Length': content.length
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
         if (err) return callback(err);
@@ -176,9 +176,7 @@
       //uri = "https://webcourier.push.apple.com/aps?tok=a819303f3199aa62b6be55a9aa635e29b69defc4a261c01ecf4ab4c9c3fcc9b6&ttl=43200";
       //console.log("\n\n", uri, "\n\n");
       var req = request.get(uri, {
-        headers: {
-
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        headers: fillDefaults({}, self.clientSettings.defaultHeaders),
         rejectUnauthorized: false
       }, function(err, response, body) {
         if (err) {
@@ -216,10 +214,10 @@
       });
 
       request.post(url, {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies)
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
 
@@ -247,10 +245,10 @@
       });
 
       request.post(url, {
-        headers: {
+        headers: fillDefaults({
           'Host': host,
           'Cookie': cookiesToStr(self.auth.cookies)
-        }.fillDefaults(self.clientSettings.defaultHeaders),
+        }, self.clientSettings.defaultHeaders),
         body: content
       }, function(err, response, body) {
 
@@ -267,7 +265,7 @@
         const url = "https://" + host + "/appleauth/auth";
 
         request.get(url, {
-          headers: {
+          headers: fillDefaults({
             'Referer': signInReferer,
             'Host': host,
             'Cookie': cookiesToStr(self.auth.cookies),
@@ -275,7 +273,7 @@
             'X-Apple-I-FD-Client-Info': JSON.stringify(self.clientSettings.xAppleIFDClientInfo),
             'X-Apple-ID-Session-Id': self.clientSettings.xAppleIDSessionId,
             'scnt': self.clientSettings.scnt
-          }.fillDefaults(self.clientSettings.defaultHeaders),
+          }, self.clientSettings.defaultHeaders),
           //body: content
         }, (err, response, body) => {
           if (err) reject(err);
@@ -290,7 +288,7 @@
         request({
           url: "https://" + host + "/appleauth/auth/verify/trusteddevice/securitycode",
           method: method,
-          headers: {
+          headers: fillDefaults({
             'Content-Type': 'application/json',
             'Referer': signInReferer,
             'Host': host,
@@ -299,7 +297,7 @@
             'X-Apple-I-FD-Client-Info': JSON.stringify(self.clientSettings.xAppleIFDClientInfo),
             'X-Apple-ID-Session-Id': self.clientSettings.xAppleIDSessionId,
             'scnt': self.clientSettings.scnt
-          }.fillDefaults(self.clientSettings.defaultHeaders),
+          }, self.clientSettings.defaultHeaders),
           body: JSON.stringify(bodyObj)
         }, function(err, response, body) {
           if (err) return reject(err);
@@ -315,7 +313,7 @@
         request({
           url: "https://" + host + "/appleauth/auth/verify/phone",
           method: "PUT",
-          headers: {
+          headers: fillDefaults({
             'Content-Type': 'application/json',
             'Referer': signInReferer,
             'Host': host,
@@ -324,7 +322,7 @@
             'X-Apple-I-FD-Client-Info': JSON.stringify(self.clientSettings.xAppleIFDClientInfo),
             'X-Apple-ID-Session-Id': self.clientSettings.xAppleIDSessionId,
             'scnt': self.clientSettings.scnt
-          }.fillDefaults(self.clientSettings.defaultHeaders),
+          }, self.clientSettings.defaultHeaders),
           body: JSON.stringify({
             phoneNumber: {
               id: 1
@@ -343,7 +341,7 @@
       const signInReferer = "https://" + host + "/appleauth/auth/signin?widgetKey=" + self.clientSettings.xAppleWidgetKey + "&locale=" + self.clientSettings.locale + "&font=sf";
       return new Promise(function(resolve, reject) {
         request.post("https://" + host + "/appleauth/auth/2sv/trust", {
-          headers: {
+          headers: fillDefaults({
             'Content-Type': 'application/json',
             'Referer': signInReferer,
             'Host': host,
@@ -352,7 +350,7 @@
             'X-Apple-I-FD-Client-Info': JSON.stringify(self.clientSettings.xAppleIFDClientInfo),
             'X-Apple-ID-Session-Id': self.clientSettings.xAppleIDSessionId,
             'scnt': self.clientSettings.scnt
-          }.fillDefaults(self.clientSettings.defaultHeaders)
+          }, self.clientSettings.defaultHeaders)
         }, function(err, response, body) {
           if (err) return reject(err);
 


### PR DESCRIPTION
Basically, you broke my project :)

Jokes aside, you are defining a `Object.prototype.fillDefaults` method that breaks code that relies on `for (var x in Object)` to cycle over Objects without using `hasOwnProperty`.

You can read more about this problem here: http://adripofjavascript.com/blog/drips/the-uses-of-in-vs-hasownproperty.html

For example: https://github.com/zvictor/ArgueJS/blob/master/argue.js#L68

Yes, I know, it's an old library, but for example Google uses it.

I rewritten all the library to don't use `fillDefaults` from Object but from helpers instead.