### PR TITLE
Process sessionInit on nextTick

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,7 +36,10 @@ class iCloud extends EventEmitter {
     }
     else {
       // The given session argument is actually an object literal, therefore there is no file to be read. Continue :)
-      sessionInit(session);
+      process.nextTick(() => {
+        sessionInit(session);
+      });
+
     }
 
     var currTopics = self.Setup.getPushTopics(self.apps);


### PR DESCRIPTION
The ready event is not fired when an already parsed valid session object is used in the constructor.