### PR TITLE
Fix logic that detects if user is logged in or not.

### DIFF
--- a/main.js
+++ b/main.js
@@ -111,8 +111,8 @@ class iCloud extends EventEmitter {
 
       // Now, validate the session with checking for important aspects that show that the session can be used to get data (e.g. there need to be a token, some cookies and account info)
       self.loggedIn = (function() {
-        //console.log(self.auth.cookies.length > 0, !!self.auth.token, self.account != {}, self.username === username);
-        return ((self.auth.cookies.length > 0) && (self.auth.token && self.account != {}) && (username ? (self.username === username) : true));
+        //console.log(self.auth.cookies.length > 0, !!self.auth.token, Object.keys(self.account).length > 0, self.username === username);
+        return ((self.auth.cookies.length > 0) && (self.auth.token && Object.keys(self.account).length > 0) && (username ? (self.username === username) : false));
       })();
 
 


### PR DESCRIPTION
At line 113 of main.js, self.loggedIn was always true when a session does not exist. This is because if a session didn't exist, the function returns "true" instead of false.

Additionally, "self.account != {}" is false even if self.account is {}. Better check for if object is empty instead.